### PR TITLE
Fix: Changeв wrong link to the Speaking JS: Array

### DIFF
--- a/01-syntax/03-data-structures/data-structures.md
+++ b/01-syntax/03-data-structures/data-structures.md
@@ -10,7 +10,7 @@
 
 ### Additional
 
-1. [Speaking JavaScript: Arrays](http://speakingjs.com/es5/ch07.html)
+1. [Speaking JavaScript: Arrays](http://speakingjs.com/es5/ch18.html)
 1. JavaScript for Web Developers: Reference Type
 
 > You may found it useful  to split `JavaScript for Web Developers: Reference Type` in few issues and read piece by piece


### PR DESCRIPTION
[Chapter №7](http://speakingjs.com/es5/ch07.html) is "JavaScrypt's Syntax". Chapter is changed from №7 to [№18 ("Arrays")](http://speakingjs.com/es5/ch18.html)
