### PR TITLE
Fix: Changed wrong link to the chapter from Speaking JS

### DIFF
--- a/01-syntax/04-high-order-functions/high-order-functions.md
+++ b/01-syntax/04-high-order-functions/high-order-functions.md
@@ -4,7 +4,7 @@
 
 ### Theory
 
-1. [Speaking JavaScript: Functions](http://speakingjs.com/es5/ch14.html)
+1. [Speaking JavaScript: Functions](http://speakingjs.com/es5/ch15.html)
 1. [Eloquent JavaScript: High-order Functions](http://eloquentjavascript.net/05_higher_order.html)
 1. [Functions Explained](http://markdaggett.com/blog/2013/02/15/functions-explained/)
 


### PR DESCRIPTION
I have changed wrong link to the chapter **Speaking JS: Functions** from [Chapter 14: Exception Handling](http://speakingjs.com/es5/ch14.html) to [Functions](http://speakingjs.com/es5/ch15.html)
